### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
+  pages: write
 jobs:
   gh-pages-deploy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/1](https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient for most steps, while the `pages: write` permission is required for the `Deploy` step to publish the site to GitHub Pages. This ensures that no unnecessary write permissions are granted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
