### PR TITLE
Potential fix for code scanning alert no. 10: Expression has no effect

### DIFF
--- a/assets/js/simple-jekyll-search.js
+++ b/assets/js/simple-jekyll-search.js
@@ -264,8 +264,6 @@
     }
   }
   
-  'use strict'
-  
   var _$utils_9 = {
     merge: merge,
     isJSON: isJSON


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/10](https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/10)

To fix the issue, the redundant `'use strict'` directive on line 267 should be removed. This will eliminate the unnecessary expression without affecting the behavior of the script, as strict mode is already enabled globally at the beginning of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
