### PR TITLE
Potential fix for code scanning alert no. 9: Expression has no effect

### DIFF
--- a/assets/js/simple-jekyll-search.js
+++ b/assets/js/simple-jekyll-search.js
@@ -229,7 +229,6 @@
     return window.XMLHttpRequest ? new window.XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP')
   }
   
-  'use strict'
   
   var _$OptionsValidator_3 = function OptionsValidator (params) {
     if (!validateParams(params)) {


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/9](https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/9)

To fix the issue, the redundant `'use strict'` directive on line 232 should be removed. The script is already in strict mode due to the directive on line 8, so removing the second occurrence will not change the behavior of the code. This change ensures that the code is cleaner and avoids unnecessary repetition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
