### PR TITLE
Potential fix for code scanning alert no. 8: Expression has no effect

### DIFF
--- a/assets/js/simple-jekyll-search.js
+++ b/assets/js/simple-jekyll-search.js
@@ -200,8 +200,6 @@
   
   /* globals ActiveXObject:false */
   
-  'use strict'
-  
   var _$JSONLoader_2 = {
     load: load
   }


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/8](https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/8)

To fix the issue, the redundant `'use strict'` directive on line 203 should be removed. This will eliminate the unnecessary expression without affecting the behavior of the code. The first `'use strict'` directive on line 8 will continue to enforce strict mode for the entire script.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
