### PR TITLE
Potential fix for code scanning alert no. 7: Expression has no effect

### DIFF
--- a/assets/js/simple-jekyll-search.js
+++ b/assets/js/simple-jekyll-search.js
@@ -89,7 +89,6 @@
     }
   }
   
-  'use strict'
   
   var _$Repository_4 = {
     put: put,


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/7](https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/7)

To fix the problem, the redundant `'use strict'` directive on line 92 should be removed. This will eliminate the unnecessary expression and make the code cleaner and easier to understand. No additional imports, methods, or definitions are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
