### PR TITLE
Potential fix for code scanning alert no. 6: Expression has no effect

### DIFF
--- a/assets/js/simple-jekyll-search.js
+++ b/assets/js/simple-jekyll-search.js
@@ -72,7 +72,6 @@
     }
   }
   
-  'use strict'
   
   var _$LiteralSearchStrategy_6 = new LiteralSearchStrategy()
   


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/6](https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/6)

To fix the issue, the redundant `'use strict'` directive on line 75 should be removed. This will eliminate the unnecessary expression and improve code clarity. The other `'use strict'` directives in the code (e.g., on lines 8, 38, and 63) are sufficient to enforce strict mode where needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
