### PR TITLE
Potential fix for code scanning alert no. 4: Expression has no effect

### DIFF
--- a/assets/js/simple-jekyll-search.js
+++ b/assets/js/simple-jekyll-search.js
@@ -35,7 +35,6 @@
     })
   }
   
-  'use strict';
   
   function fuzzysearch (needle, haystack) {
     var tlen = haystack.length;


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/4](https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/4)

To fix the issue, the redundant `'use strict'` directive on line 38 should be removed. This will eliminate the unnecessary expression and make the code cleaner without altering its functionality. The first `'use strict'` directive on line 8 is sufficient to enforce strict mode for the entire script.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
