### PR TITLE
Potential fix for code scanning alert no. 5: Expression has no effect

### DIFF
--- a/assets/js/simple-jekyll-search.js
+++ b/assets/js/simple-jekyll-search.js
@@ -60,7 +60,7 @@
   
   var _$fuzzysearch_1 = fuzzysearch;
   
-  'use strict'
+  
   
   /* removed: const _$fuzzysearch_1 = require('fuzzysearch') */;
   


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/5](https://github.com/SinaKitagami/sina-helpcenter/security/code-scanning/5)

To fix the issue, the redundant `'use strict'` directive on line 63 should be removed. The directive on line 8 already enforces strict mode for the entire script, so the one on line 63 is unnecessary. This change will not affect the functionality of the code but will eliminate the flagged issue and improve code readability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
